### PR TITLE
Setup Spring Boot JDK 21 project with Dependabot and branch sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,35 @@
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions
+  # Enable version updates for Maven
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    # Specify which dependency updates should trigger security-update PRs
+    # when security vulnerabilities are detected 
+    security-updates: true
+    # Assign the pull requests to specific reviewers
+    assignees:
+      - "vinayp1277"
+    # Labels to apply to pull requests
+    labels:
+      - "dependencies"
+      - "security"
+    # Allow up to 3 pull requests for dependencies
+    pull-request-branch-name:
+      separator: "-"
+    # Advanced settings
+    commit-message:
+      prefix: "dependabot"
+      include: "scope"
+      
+  # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
-
-  # Maintain dependencies for npm
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    
-  # Maintain dependencies for pip
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "actions"

--- a/.github/workflows/sync-master-to-master-jdk21.yml
+++ b/.github/workflows/sync-master-to-master-jdk21.yml
@@ -1,45 +1,20 @@
 name: Sync master to master-jdk21
-
 on:
   push:
     branches:
       - master
-
 jobs:
   sync-branches:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - name: Configure Git
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-
-      - name: Create sync PR
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Fetch the latest changes from both branches
-          git fetch origin master
-          git fetch origin master-jdk21
-          
-          # Create a new branch for the sync PR
-          SYNC_BRANCH="sync-master-to-jdk21-$(date +%Y%m%d%H%M%S)"
-          git checkout -b $SYNC_BRANCH origin/master-jdk21
-          
-          # Merge master into the sync branch
-          git merge origin/master --no-edit
-          
-          # Push the sync branch to the repository
-          git push origin $SYNC_BRANCH
-          
-          # Create a pull request
-          PR_URL=$(gh pr create --base master-jdk21 --head $SYNC_BRANCH \
-                  --title "Sync: Merge master into master-jdk21" \
-                  --body "This PR was automatically created by the sync workflow to keep master-jdk21 branch up to date with master.")
-          
-          echo "Created sync PR: $PR_URL"
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          branch: sync/master-to-master-jdk21
+          base: master-jdk21
+          title: 'Sync: master to master-jdk21'
+          body: 'Automated PR to sync changes from master to master-jdk21'

--- a/.github/workflows/sync-master-to-master-jdk21.yml
+++ b/.github/workflows/sync-master-to-master-jdk21.yml
@@ -1,0 +1,45 @@
+name: Sync master to master-jdk21
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  sync-branches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+      - name: Create sync PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Fetch the latest changes from both branches
+          git fetch origin master
+          git fetch origin master-jdk21
+          
+          # Create a new branch for the sync PR
+          SYNC_BRANCH="sync-master-to-jdk21-$(date +%Y%m%d%H%M%S)"
+          git checkout -b $SYNC_BRANCH origin/master-jdk21
+          
+          # Merge master into the sync branch
+          git merge origin/master --no-edit
+          
+          # Push the sync branch to the repository
+          git push origin $SYNC_BRANCH
+          
+          # Create a pull request
+          PR_URL=$(gh pr create --base master-jdk21 --head $SYNC_BRANCH \
+                  --title "Sync: Merge master into master-jdk21" \
+                  --body "This PR was automatically created by the sync workflow to keep master-jdk21 branch up to date with master.")
+          
+          echo "Created sync PR: $PR_URL"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,60 @@
-## Test Repository
-A test repository created via Claude.
+# Spring Boot JDK 21 Demo
+
+This is a simple Spring Boot project configured with JDK 21. The project demonstrates:
+
+1. Basic Spring Boot web application setup
+2. Using JDK 21 features
+3. Dependency management with Maven
+4. Dependabot security scanning and automated updates
+5. GitHub Actions workflow for automatic branch synchronization
+
+## Project Structure
+
+```
+├── src/main/java/
+│   └── com/example/demo/
+│       ├── DemoApplication.java (Main application class)
+│       └── controller/
+│           └── HelloController.java (Simple REST controller)
+├── src/main/resources/
+│   └── application.properties (Application configuration)
+├── .github/
+│   ├── dependabot.yml (Dependabot configuration)
+│   └── workflows/
+│       └── sync-master-to-master-jdk21.yml (Branch sync workflow)
+└── pom.xml (Maven configuration)
+```
+
+## Features
+
+### Spring Boot Setup
+- Spring Boot 3.2.0
+- JDK 21
+- Spring Web for REST APIs
+- Spring Data JPA with H2 database
+- Spring Boot Actuator for monitoring
+
+### Dependabot Configuration
+The project is configured with Dependabot to:
+- Scan for vulnerable dependencies weekly
+- Create automated PRs for security updates
+- Apply appropriate labels and assignees
+
+### GitHub Actions Workflow
+The repository includes a GitHub Actions workflow that:
+- Monitors for pushes to the `master` branch
+- Automatically creates a PR to sync changes from `master` to `master-jdk21`
+
+## Getting Started
+
+To run this application locally:
+
+```bash
+./mvnw spring-boot:run
+```
+
+The application will be available at http://localhost:8080
+
+## Branches
+- `master`: Main development branch
+- `master-jdk21`: JDK 21 specific branch that stays in sync with master

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.2.0</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.example</groupId>
+	<artifactId>demo</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>demo</name>
+	<description>Demo project for Spring Boot with JDK 21</description>
+	<properties>
+		<java.version>21</java.version>
+		<snakeyaml.version>2.0</snakeyaml.version>
+		<jackson.version>2.15.2</jackson.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.yaml</groupId>
+			<artifactId>snakeyaml</artifactId>
+			<version>${snakeyaml.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>${jackson.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -1,0 +1,13 @@
+package com.example.demo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemoApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(DemoApplication.class, args);
+	}
+
+}

--- a/src/main/java/com/example/demo/controller/HelloController.java
+++ b/src/main/java/com/example/demo/controller/HelloController.java
@@ -1,0 +1,13 @@
+package com.example.demo.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+    @GetMapping("/")
+    public String hello() {
+        return "Hello from Spring Boot with JDK 21!";
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,13 @@
+# Server configuration
+server.port=8080
+
+# H2 Database configuration
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=password
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.h2.console.enabled=true
+
+# Actuator endpoints
+management.endpoints.web.exposure.include=health,info,metrics


### PR DESCRIPTION
## Changes in this PR

This PR sets up a Spring Boot project with JDK 21 support, adding:

1. **Spring Boot Application**
   - Basic Spring Boot web application with JDK 21
   - Simple REST controller
   - H2 database configuration
   - Spring Boot Actuator endpoints

2. **Dependabot Configuration**
   - Weekly security scans for Maven dependencies
   - Automated PR creation for security updates
   - Custom labeling and assignment

3. **GitHub Actions Workflow**
   - Automatic branch synchronization
   - Creates PRs to merge changes from `master` to `master-jdk21`
   - Runs whenever code is pushed to `master`

4. **Documentation**
   - Comprehensive README.md with project details
   - Project structure explanation
   - Usage instructions

Once merged to `master`, the GitHub Actions workflow will automatically create PRs to keep the `master-jdk21` branch in sync with `master`.
